### PR TITLE
Use new helper API

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 target
+Cargo.lock

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,5 +5,5 @@ version = "0.1.0"
 readme = "README.md"
 
 [dependencies]
-handlebars = "0.29.1"
+handlebars = { git = "https://github.com/sunng87/handlebars-rust.git" }
 serde_json = "1.0.3"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,12 +2,13 @@ extern crate handlebars;
 extern crate serde_json;
 
 use handlebars::Handlebars;
-use serde_json::{to_writer as json_to_writer, to_string as json_to_string};
 
-#[macro_use] mod macros;
+#[macro_use]
+mod macros;
 
 mod helpers {
     use handlebars;
+    use serde_json;
 
     handlebars_helper!(gt: |x: u64, y: u64| x > y);
     handlebars_helper!(gte: |x: u64, y: u64| x >= y);

--- a/tests/conditions.rs
+++ b/tests/conditions.rs
@@ -1,6 +1,7 @@
 extern crate handlebars;
 extern crate handlebars_helpers;
-#[macro_use] extern crate serde_json;
+#[macro_use]
+extern crate serde_json;
 
 use handlebars::Handlebars;
 
@@ -9,13 +10,16 @@ fn nested_conditions() {
     let mut handlebars = Handlebars::new();
     handlebars_helpers::register(&mut handlebars);
 
-    let result = handlebars.template_render(
-        "{{#if (gt 5 3)}}lorem{{else}}ipsum{{/if}}", &json!({})
-    ).unwrap();
+    let result = handlebars
+        .template_render("{{#if (gt 5 3)}}lorem{{else}}ipsum{{/if}}", &json!({}))
+        .unwrap();
     assert_eq!(&result, "lorem");
 
-    // let result = handlebars.template_render(
-    //     "{{#if (not (gt 5 3))}}lorem{{else}}ipsum{{/if}}", &json!({})
-    // ).unwrap();
-    // assert_eq!(&result, "ipsum");
+    let result = handlebars
+        .template_render(
+            "{{#if (not (gt 5 3))}}lorem{{else}}ipsum{{/if}}",
+            &json!({}),
+        )
+        .unwrap();
+    assert_eq!(&result, "ipsum");
 }


### PR DESCRIPTION
I have been working on a new helper API that returns a `serde_json::Value`, which fit the scenario like `gt`, `not`, `plus` etc.

This patch uses git version of handlebars-rust. I might have some other updates before final release. I will keep you updated. 