### PR TITLE
Update to latest handlebars release

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,5 +5,5 @@ version = "0.1.0"
 readme = "README.md"
 
 [dependencies]
-handlebars = { git = "https://github.com/sunng87/handlebars-rust.git" }
-serde_json = "1.0.3"
+handlebars = "^0.30.0"
+serde_json = "^1.0.3"

--- a/tests/conditions.rs
+++ b/tests/conditions.rs
@@ -11,12 +11,12 @@ fn nested_conditions() {
     handlebars_helpers::register(&mut handlebars);
 
     let result = handlebars
-        .template_render("{{#if (gt 5 3)}}lorem{{else}}ipsum{{/if}}", &json!({}))
+        .render_template("{{#if (gt 5 3)}}lorem{{else}}ipsum{{/if}}", &json!({}))
         .unwrap();
     assert_eq!(&result, "lorem");
 
     let result = handlebars
-        .template_render(
+        .render_template(
             "{{#if (not (gt 5 3))}}lorem{{else}}ipsum{{/if}}",
             &json!({}),
         )


### PR DESCRIPTION
Fixes #1 

Handlebars 0.30.0 has been released. And we should be able to use this library now. 